### PR TITLE
Update launcher.py

### DIFF
--- a/webcamstreamer/launcher.py
+++ b/webcamstreamer/launcher.py
@@ -38,7 +38,7 @@ def main():
 
     config = configparser.ConfigParser()
 
-    from streamer.defaults import defaults
+    from .streamer.defaults import defaults
     defaults_buf = StringIO.StringIO(defaults)
     try:
         config.read_file(defaults_buf)


### PR DESCRIPTION
add '.' to prevent 
```
  File "C:\Users\User\django-t\django_venv\Scripts\webcam-streamer-script.py", line 11, in <module>
    load_entry_point('webcam-streamer==1.0.5', 'console_scripts', 'webcam-streamer')()
  File "C:\Users\User\django-t\django_venv\lib\site-packages\webcam_streamer-1.0.5-py3.5.egg\webcamstreamer\launcher.py", line 41, in main
    from streamer.defaults import defaults
ImportError: No module named 'streamer'
```